### PR TITLE
feat: BIOINFO-45 add nextflow image and associated github workflows

### DIFF
--- a/.github/workflows/publish_with_latest_nextflow.yml
+++ b/.github/workflows/publish_with_latest_nextflow.yml
@@ -1,0 +1,22 @@
+name: Publish Image Using latest
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-nextflow:
+    name: Publish Nextflow Image latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/nextflow
+          location: nextflow
+          dockerfile: nextflow/Dockerfile
+          tag_format: "latest"

--- a/.github/workflows/publish_with_semver_tag_nextflow.yml
+++ b/.github/workflows/publish_with_semver_tag_nextflow.yml
@@ -1,0 +1,25 @@
+name: Publish Image Using Semver Tag
+
+on:
+  push:
+    tags:
+      - nextflow-v*
+
+jobs:
+  publish-nextflow:
+    name: Publish Nextflow Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract Version Tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/nextflow-v}" >> $GITHUB_ENV
+      - name: Push the image on the registry
+        uses: Ferlab-Ste-Justine/action-push-image@v2
+        with:
+          username: ${{ secrets.FERLAB_DOCKER_HUB_USER }}
+          password: ${{ secrets.FERLAB_DOCKER_HUB_TOKEN }}
+          image: ferlabcrsj/nextflow
+          location: nextflow
+          dockerfile: nextflow/Dockerfile
+          tag_format: "${{ env.VERSION }}"

--- a/.github/workflows/trivy_check_nextflow.yml
+++ b/.github/workflows/trivy_check_nextflow.yml
@@ -1,0 +1,46 @@
+name: Security Scan with Trivy
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths: 
+      - 'nextflow/**'
+
+permissions:
+  contents: read
+  security-events: read
+
+jobs:
+  scan-docker-image-nextflow:
+    name: Scan Nextflow Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Build Docker Image
+        run: docker build -t ferlabcrsj/nextflow:${{ github.sha }} -f nextflow/Dockerfile nextflow
+      - name: Run Trivy Image scan (Docker)
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          scan-type: 'image'
+          image-ref: 'ferlabcrsj/nextflow:${{ github.sha }}'
+          format: 'table'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          trivyignores: 'nextflow/.trivyignore_image'
+
+  scan-docker-file-nextflow:
+    name: Scan Nextflow Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run Trivy Dockerfile scan
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          scan-type: 'conf'
+          scan-ref: 'nextflow'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          trivyignores: 'nextflow/.trivyignore_config'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # nextflow-docker-images
 A collection of docker images designed for use with nextflow pipelines.
+
+
+
+## Images
+
+### Nextflow
+This docker image is designed to create long-running Nextflow pods. It includes nextflow and several command-line
+utilities such as the AWS CLI and Rclone. Additionally, it provides more basic linux commands like tar, which are 
+not included in the base nextflow image.
+
+
+## Local Testing Commands
+
+Here are example commands for the Nextflow image. You can adapt these commands for other images as needed.
+
+#### Building the Docker Image
+
+To build it locally, you can use the following command from the project root directory:
+
+```
+docker build nextflow -t ferlabcrsj/nextflow:dev
+```
+
+#### Running the Docker Container
+To open a shell on a docker container created from this image, run the following command:
+
+```
+docker run -it --rm ferlabcrsj/nextflow:dev /bin/bash
+```
+
+
+Since the `--rm` option is specified, the container will be automatically deleted once you exit the shell.
+
+If you are using a different image, make sure to change the image tag (ferlabcrsj/nextflow:dev) accordingly.
+
+#### Running trivy checks
+
+```
+trivy image --severity HIGH,CRITICAL --exit-code 1  --ignorefile nextflow/.trivyignore_image ferlabcrsj/nextflow:dev
+
+trivy conf --severity 'HIGH,CRITICAL' nextflow --ignorefile nextflow/.trivyignore_config
+```

--- a/nextflow/.trivyignore_config
+++ b/nextflow/.trivyignore_config
@@ -1,0 +1,7 @@
+# DOCKERFILE VULNERABILITIES
+
+# AVD-DS-0002 | HIGH | Specify at least 1 USER command in Dockerfile with non-root user as argument
+AVD-DS-0002
+
+# AVD-DS-0015 | HIGH |'yum clean all' is missed
+AVD-DS-0015

--- a/nextflow/.trivyignore_image
+++ b/nextflow/.trivyignore_image
@@ -1,0 +1,27 @@
+## DOCKER IMAGE VULNERABILITIES
+
+#  These vulnerabilities come from nextflow dependencies (java).
+#  It will ve very hard to get rid of them, so we tolerate them for now.
+#  We hope reducing the number of vulnerabilities when we update the nextflow version.
+
+
+# logback 1.4.11 │ CVE-2023-6378 │ HIGH |  serialization vulnerability in logback receiver 
+CVE-2023-6378
+
+# apache-commons-io >=2.0 and <2.14.0 │ CVE-2024-47554 │ HIGH │ Possible denial of service attack on untrusted input to XmlStreamReader
+CVE-2024-47554
+
+# apache-ivy < 2.5.0 | CVE-2022-46751 │ HIGH │ XML External Entity vulnerability
+CVE-2022-46751 
+
+# jgit <= 6.6.0 │ CVE-2023-4759 │ HIGH │ arbitrary file overwrite
+CVE-2023-4759
+
+# pf4j <= v.3.9.0 │ CVE-2023-40826 │ HIGH │ allows a remote attacker to obtain sensitive information and execute arbitrary code via the zippluginPath parameter
+CVE-2023-40826 
+
+# pf4j <= v.3.9.0 │ CVE-2023-40827 │ HIGH │ allows a remote attacker to obtain sensitive information and execute arbitrary code via the loadpluginPath parameter
+CVE-2023-40827
+
+# pf4j <= v.3.9.0 │ CVE-2023-40828 │ HIGH │ allows a remote attacker to obtain sensitive information and execute arbitrary code via the expandIfZip method in the extract function
+CVE-2023-40828

--- a/nextflow/CHANGELOG.md
+++ b/nextflow/CHANGELOG.md
@@ -1,0 +1,10 @@
+# ferlabcrsj/nextflow Image Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## Unreleased
+
+### `Added`
+- [#TODO] Copy nextflow docker image from Post-processing-Pipeline repo (v2.8.1)

--- a/nextflow/Dockerfile
+++ b/nextflow/Dockerfile
@@ -1,0 +1,19 @@
+# The container created from this image is used as a jump point within the
+# kubernetes cluster to submit various ad-hoc jobs.
+
+FROM nextflow/nextflow:23.10.1
+
+# Adding a few command line utilities
+RUN yum update -y && yum install -y --setopt=skip_missing_names_on_install=False \
+nano-2.9.8-2.amzn2.0.1.x86_64 \
+tar-2:1.26-35.amzn2.0.3.x86_64 \
+less-458-9.amzn2.0.4.x86_64 \
+wget-1.14-18.amzn2.1.x86_64 \
+unzip-6.0-57.amzn2.0.1.x86_64 \
+zip-3.0-11.amzn2.0.2.x86_64 \
+rclone-1.55.1-1.amzn2.0.1.x86_64
+
+# Installing the aws cli. Using version >= 2.13.0 so that environment variable AWS_ENDPOINT_URL is supported
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.13.0.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install


### PR DESCRIPTION
This pull request introduces the ferlab nextflow docker image, which is designed for nextflow long-running pods.

It has been copied from the Post-processing-Pipeline repository. Once all images from that repository have been migrated to this one, they will be removed from the Post-processing-Pipeline repository.

Additionally, this pull request includes github workflows for building and publishing the image  and performing Trivy security checks.

**Implementation details**

Inspiration:
- publish logic: https://github.com/Ferlab-Ste-Justine/custom-docker-images
- trivy check: https://github.com/Ferlab-Ste-Justine/unic-portal-ui/tree/main

Image organisation:  Each image is placed in its own folder (e.g., nextflow) to group related files together (Dockerfile, .trivyignore and CHANGELOG).

Publish behaviour:  Github tags are prefixed per image (e.g., github tag `nextflow-v1.5.0` will publish image `ferlabcrsj/nextflow:1.5.0`). For push on the main branch, only `ferlabcrsj/nextflow:latest` is published.

Trivy checks:  Configured Trivy to scan the docker image and the dockerfile.  File system (fs) checks are excluded because no supported files are detected.

Trivyignore files:  The nextflow image is copied from another repository and preserved as-is for the initial copy.
All current Trivy warnings are added to .trivyignore files.  New .trivyignore files will be created when we switch to a more recent nextflow version, which is expected to reduce vulnerabilities.  This update is planned soon. As part of this update, we will also try to address vulnerabilities in the Dockerfile.