### PR TITLE
feat: BIOINFO-45 update nextflow to 24.10.5

### DIFF
--- a/nextflow/.trivyignore_config
+++ b/nextflow/.trivyignore_config
@@ -2,6 +2,3 @@
 
 # AVD-DS-0002 | HIGH | Specify at least 1 USER command in Dockerfile with non-root user as argument
 AVD-DS-0002
-
-# AVD-DS-0015 | HIGH |'yum clean all' is missed
-AVD-DS-0015

--- a/nextflow/.trivyignore_image
+++ b/nextflow/.trivyignore_image
@@ -1,27 +1,56 @@
-## DOCKER IMAGE VULNERABILITIES
+# This file is used to ignore vulnerabilities in the docker image
 
-#  These vulnerabilities come from nextflow dependencies (java).
-#  It will ve very hard to get rid of them, so we tolerate them for now.
-#  We hope reducing the number of vulnerabilities when we update the nextflow version.
+##############################################################################
+#  VULNERABILITIES FROM THE ROOT DOCKER IMAGE: amazoncorretto:21-al2023      #
+#                                                                            #
+#  These would be hard to fix, as they are part of the base image used by    #
+#  the nextflow docker image that we depend on. We will ignore them for now. #
+#                                                                            #
+##############################################################################
 
+# java-21-amazon-corretto  < 1:21.0.7+6-1 | CVE-2025-21587 | HIGH | openjdk: Better TLS connection support (Oracle CPU 2025-04)
+CVE-2025-21587
 
-# logback 1.4.11 │ CVE-2023-6378 │ HIGH |  serialization vulnerability in logback receiver 
-CVE-2023-6378
+# java-21-amazon-corretto  < 1:21.0.7+6-1 | CVE-2025-30691 | HIGH | openjdk: Improve compiler transformations (Oracle CPU 2025-04)
+CVE-2025-30691
+
+# java-21-amazon-corretto  < 1:21.0.7+6-1 | CVE-2025-30698 | HIGH |  openjdk: Enhance Buffered Image handling (Oracle CPU 2025-04)
+CVE-2025-30698
+
+# libcap  < 2.48-2.amzn2023.0.4 | CVE-2025-1390 | HIGH | libcap: pam_cap: Fix potential configuration parsing error
+CVE-2025-1390
+
+# libxml2 < 2.10.4-1.amzn2023.0.9 | CVE-2024-56171 | HIGH | libxml2: Use-After-Free in libxml2
+CVE-2024-56171
+
+# libxml2 < 2.10.4-1.amzn2023.0.9 | CVE-2025-24928 | HIGH | libxml2: Stack-based buffer overflow in xmlSnprintfElements of libxml2
+CVE-2025-24928
+
+# libxml2 < 2.10.4-1.amzn2023.0.9 |  CVE-2025-27113 | HIGH | libxml2: NULL Pointer Dereference in libxml2 xmlPatMatch
+CVE-2025-27113
+
+#############################################################
+# VULNERABILITIES FROM NEXTFLOW DEPENDENCIES (JAVA)         #
+#                                                           #
+# These are vulnerabilities in the java libraries used by   #
+# nextflow. We will ignore them for now.                    #
+#############################################################
 
 # apache-commons-io >=2.0 and <2.14.0 │ CVE-2024-47554 │ HIGH │ Possible denial of service attack on untrusted input to XmlStreamReader
 CVE-2024-47554
 
-# apache-ivy < 2.5.0 | CVE-2022-46751 │ HIGH │ XML External Entity vulnerability
-CVE-2022-46751 
+########################################################
+# VULNERABILITIES FROM INSTALLED TOOLS (BINARY)        #
+#                                                      #
+# These are vulnerabilities in the tools installed     #
+# on top of the nextflow image.                        #
+#                                                      #
+# We think that there is low risk of exposure because  #
+# these tools are not part of an automated process or  #
+# external-facing service. They are only used manually #
+# by trusted users.                                    #
+#                                                      #
+########################################################
 
-# jgit <= 6.6.0 │ CVE-2023-4759 │ HIGH │ arbitrary file overwrite
-CVE-2023-4759
-
-# pf4j <= v.3.9.0 │ CVE-2023-40826 │ HIGH │ allows a remote attacker to obtain sensitive information and execute arbitrary code via the zippluginPath parameter
-CVE-2023-40826 
-
-# pf4j <= v.3.9.0 │ CVE-2023-40827 │ HIGH │ allows a remote attacker to obtain sensitive information and execute arbitrary code via the loadpluginPath parameter
-CVE-2023-40827
-
-# pf4j <= v.3.9.0 │ CVE-2023-40828 │ HIGH │ allows a remote attacker to obtain sensitive information and execute arbitrary code via the expandIfZip method in the extract function
-CVE-2023-40828
+# rclone, github.com/golang-jwt/jwt/v5 <5.2.2 | CVE-2025-30204 | HIGH | golang-jwt/jwt: jwt-go allows excessive memory allocation during header parsing
+CVE-2025-30204

--- a/nextflow/CHANGELOG.md
+++ b/nextflow/CHANGELOG.md
@@ -3,8 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## Unreleased
 
 ### `Added`
-- [#TODO] Copy nextflow docker image from Post-processing-Pipeline repo (v2.8.1)
+- [#6](https://github.com/Ferlab-Ste-Justine/nextflow-docker-images/pull/6) Copy nextflow docker image from Post-processing-Pipeline repo (v2.8.1)
+
+### `Changed`
+- [#7](https://github.com/Ferlab-Ste-Justine/nextflow-docker-images/pull/7) Update nextflow version from 23.10.1 to 24.10.5

--- a/nextflow/Dockerfile
+++ b/nextflow/Dockerfile
@@ -1,19 +1,20 @@
 # The container created from this image is used as a jump point within the
 # kubernetes cluster to submit various ad-hoc jobs.
 
-FROM nextflow/nextflow:23.10.1
+FROM nextflow/nextflow:24.10.5
 
 # Adding a few command line utilities
 RUN yum update -y && yum install -y --setopt=skip_missing_names_on_install=False \
-nano-2.9.8-2.amzn2.0.1.x86_64 \
-tar-2:1.26-35.amzn2.0.3.x86_64 \
-less-458-9.amzn2.0.4.x86_64 \
-wget-1.14-18.amzn2.1.x86_64 \
-unzip-6.0-57.amzn2.0.1.x86_64 \
-zip-3.0-11.amzn2.0.2.x86_64 \
-rclone-1.55.1-1.amzn2.0.1.x86_64
+nano-5.8-3.amzn2023.0.4.x86_64 \
+tar-2:1.34-1.amzn2023.0.4.x86_64 \
+less-608-2.amzn2023.0.2.x86_64 \
+wget-1.21.3-1.amzn2023.0.4.x86_64 \
+unzip-6.0-57.amzn2023.0.2.x86_64 \
+zip-3.0-28.amzn2023.0.2.x86_64 \
+awscli-2-2.17.18-1.amzn2023.0.1 \
+&& yum clean all
 
-# Installing the aws cli. Using version >= 2.13.0 so that environment variable AWS_ENDPOINT_URL is supported
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.13.0.zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
-RUN ./aws/install
+RUN curl "https://downloads.rclone.org/v1.69.2/rclone-v1.69.2-linux-amd64.zip" -o "rclone.zip" && \
+    unzip rclone.zip && \
+    cp rclone-v1.69.2-linux-amd64/rclone /usr/local/bin/rclone && \
+    rm -rf rclone-v1.69.2-linux-amd64 rclone.zip


### PR DESCRIPTION
This pull request update the nextflow version in our nextflow docker image.
More precisely, we update from 23.10.1 to 24.10.5.

**Changes**

-  Updated Nextflow to the latest stable version (24.10.5).
-  Updated the versions of tools installed on the image to ensure compatibility
-  Revised the list of ignored Trivy vulnerabilities to reflect the changes in the base image (amazoncorretto:21-al2023) and the updated tools. More details below.

**Trivy Vulnerabilities**

We revised the list of ignored trivy vulnerabilities.

Vulnerabilities coming from nextflow base image:
- Most vulnerabilities related to nextflow dependencies (java) have been resolved. 
- However, new vulnerabilities have appeared due to the root image (amazoncorretto:21-al2023), which we cannot control.

Vulnerabilities introduced in our dockerfile:
- A new vulnerability was introduced for the rclone library (CVE-2025-30204). With the previous version (1.55.1), we did not have reported vulnerabilities, but it might be because it was too old (2021).  We tested all other 2024 or 2025 versions, but we did not found any without reported vulnerability.  So, finally, we chose to use the more recent version available.
- We fixed a warning caused by a missing `yum clean all` command in the Dockerfile.

