### PR TITLE
feat: BIOINFO-45 bump ferlabcrsj/nextflow image version to v3.0.0

### DIFF
--- a/nextflow/CHANGELOG.md
+++ b/nextflow/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v3.0.0 - 2025-05-08
+
 ### `Added`
 - [#6](https://github.com/Ferlab-Ste-Justine/nextflow-docker-images/pull/6) Copy nextflow docker image from Post-processing-Pipeline repo (v2.8.1)
 


### PR DESCRIPTION
This pull request updates the version of the ferlabcrsj/nextflow image.

The previous version was v2.8.1, and the new version is v3.0.0.
This change is purely documentation-related, updating the changelog to reflect the changes associated with the image.

Once this is merged, I will create and push the git tag "nextflow-v3.0.0" to publish the corresponding image on dockerhub.
The image name will be ferlabcrsj/nextflow:3.0.0