### PR TITLE
Feat/bioinfo 43 add vim and gzip to nextflow docker image

### DIFF
--- a/nextflow/CHANGELOG.md
+++ b/nextflow/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#10](https://github.com/Ferlab-Ste-Justine/nextflow-docker-images/pull/10) Update trivu warnings and rclone version
+- [#10](https://github.com/Ferlab-Ste-Justine/nextflow-docker-images/pull/10) Update trivy warnings and rclone version
+- [#11](https://github.com/Ferlab-Ste-Justine/nextflow-docker-images/pull/11) Add gzip and vim tools
 
 ## v3.0.0 - 2025-05-08
 

--- a/nextflow/Dockerfile
+++ b/nextflow/Dockerfile
@@ -4,13 +4,16 @@
 FROM nextflow/nextflow:24.10.5
 
 # Adding a few command line utilities
+# Note: gzip is required to access the nextflow pod via the vscode extension
 RUN yum update -y && yum install -y --setopt=skip_missing_names_on_install=False \
 nano-5.8-3.amzn2023.0.4.x86_64 \
+vim-enhanced-2:9.1.785-1.amzn2023.0.1.x86_64 \
 tar-2:1.34-1.amzn2023.0.4.x86_64 \
 less-608-2.amzn2023.0.2.x86_64 \
 wget-1.21.3-1.amzn2023.0.4.x86_64 \
 unzip-6.0-57.amzn2023.0.2.x86_64 \
 zip-3.0-28.amzn2023.0.2.x86_64 \
+gzip-1.12-1.amzn2023.0.1.x86_64 \
 awscli-2-2.17.18-1.amzn2023.0.1 \
 && yum clean all
 


### PR DESCRIPTION
Add vim and gzip tools to nextflow docker image.

We add gzip because it is necessary to support access to pod via vscode extension.
We are adding vim as well for comfort and convenience.

These tools are not introducing any new security vulnerabilities according to trivy (i.e. the trivy checks are still passing).
